### PR TITLE
Fix compile errors, update README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #  6/9/2014
 # ***********************************************************************
 AppEnD:AppEnD.o
-	g++ -L./bamtools/lib AppEnD.o -o AppEnD -Wl,-rpath,./bamtools/lib -lbamtools
+	g++ -L./bamtools/build/src/api AppEnD.o -o AppEnD -Wl,-rpath,./bamtools/lib -lbamtools -lz
 AppEnD.o:AppEnD.cc AppEnD.h
 	mkdir ./bamtools/build; cd ./bamtools/build; cmake ..; make
-	g++ -c -O3 AppEnD.cc -I./bamtools/include
+	g++ -c -O3 AppEnD.cc -I./bamtools/src

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 The sequence of commands to do this is:
 ```
-git clone https://jwelch%40cs.unc.edu@code.google.com/p/append/
+git clone https://github.com/jw156605/append
 cd append/
-git clone git://github.com/pezmaster31/bamtools.git
+git clone --depth 1 --branch v2.5.1 git://github.com/pezmaster31/bamtools.git
 make
 ```
 
@@ -29,5 +29,5 @@ using an aligner that performs soft clipping. For example, MapSplice, TopHat, ST
 
 To run AppEnD, simply type:
 ```
-./AppEnD <parameter file>
+./AppEnD parameter_file bam_file
 ```


### PR DESCRIPTION
This pull request fixes three compile errors, insures further errors from potential non-back-compatible to [bamtools](https://github.com/pezmaster31/bamtools), and makes minor edits to the README. The changes are detailed as follows.

**1. The following compile error**
```
g++ -c -O3 AppEnD.cc -I./bamtools/include
In file included from AppEnD.cc:8:0:
AppEnD.h:18:10: fatal error: api/BamMultiReader.h: No such file or directory
 #include "api/BamMultiReader.h"
           ^~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
Makefile:11: recipe for target 'AppEnD.o' failed
make: *** [AppEnD.o] Error 1
```
was fixed by changing the value of the `-I` flag in the relevant command from `./bamtools/include` to `./bamtools/src`.


**2. The following compile error**
```
g++ -L./bamtools/lib AppEnD.o -o AppEnD -Wl,-rpath,./bamtools/lib -lbamtools
/usr/bin/ld: cannot find -lbamtools
collect2: error: ld returned 1 exit status
Makefile:9: recipe for target 'AppEnD' failed
make: *** [AppEnD] Error 1

Fixed by the change in -L to ./bamtools/build/src/api
```
was fixed by change the value of the '-L` flag in the relevant command from `./bamtools/lib` to `./bamtools/build/src/api`.

**3. The following compile error**
```
g++ -L./bamtools/build/src/api AppEnD.o -o AppEnD -Wl,-rpath,./bamtools/lib
-lbamtools
./bamtools/build/src/api/libbamtools.a(BgzfStream_p.cpp.o): In function
`BamTools::Internal::BgzfStream::DeflateBlock(int)':
BgzfStream_p.cpp:(.text+0x199): undefined reference to `deflateEnd'
BgzfStream_p.cpp:(.text+0x1f5): undefined reference to `deflateInit2_'
BgzfStream_p.cpp:(.text+0x20c): undefined reference to `deflate'
BgzfStream_p.cpp:(.text+0x220): undefined reference to `deflateEnd'
BgzfStream_p.cpp:(.text+0x25c): undefined reference to `crc32'
BgzfStream_p.cpp:(.text+0x26a): undefined reference to `crc32'
./bamtools/build/src/api/libbamtools.a(BgzfStream_p.cpp.o): In function
`BamTools::Internal::BgzfStream::InflateBlock(unsigned long const&)':
BgzfStream_p.cpp:(.text+0x1bf8): undefined reference to `inflateInit2_'
BgzfStream_p.cpp:(.text+0x1c09): undefined reference to `inflate'
BgzfStream_p.cpp:(.text+0x1c1a): undefined reference to `inflateEnd'
BgzfStream_p.cpp:(.text+0x1ce6): undefined reference to `inflateEnd'
BgzfStream_p.cpp:(.text+0x1d68): undefined reference to `inflateEnd'
collect2: error: ld returned 1 exit status
Makefile:9: recipe for target 'AppEnD' failed
make: *** [AppEnD] Error 1
```
was fixed by adding the `-lz` flag to the relevant command.

**4. Further compile errors potentially occurring due to back-compatibility issues from bamtools** was fixed by setting the version of bamtools to be cloned and used in AppEnD's compilation in the README.
```
git clone --depth 1 --branch v2.5.1 git://github.com/pezmaster31/bamtools.git
```

**5. Minor edits were made to the README** in the URL of this repository,
```
git clone https://github.com/jw156605/append
```
as well as in the final instructional line to make it clear that two arguments (one for each file) is required
```
./AppEnD parameter_file bam_file
```